### PR TITLE
Uppdaterade terminstider, samt lade till länk.

### DIFF
--- a/src/TerminsTider.js
+++ b/src/TerminsTider.js
@@ -9,7 +9,7 @@ const TerminsTider = ({show}) => {
     <div className="Information">
       <div className="Tekfak">
         <h2>TekFak Spring 2023</h2>
-        <p><a href="https://liu.se/organisation/liu/lith/terminstider-for-tekniska-hogskolan">Also available from the source</a></p>
+        <p><a target="_blank" rel="noopener noreferrer" href="https://liu.se/organisation/liu/lith/terminstider-for-tekniska-hogskolan">Also available from the source</a></p>
         <h2>TekFak Autumn 2023</h2>
         <ul>
           <li>2023-08-28 (v 35) - 2024-01-13 (v 2)</li>

--- a/src/TerminsTider.js
+++ b/src/TerminsTider.js
@@ -9,22 +9,30 @@ const TerminsTider = ({show}) => {
     <div className="Information">
       <div className="Tekfak">
         <h2>TekFak Spring 2023</h2>
-        <ul>
-          <li>16 Jan - 10 Mar: Study period VT1</li>
-          <li>13 Mar - 13 Mar: Self study</li>
-          <li>14 Mar - 17 Mar: Re-examination period HT2</li>
-          <li>20 Mar - 25 Mar: Examination period VT1</li>
-          <li>27 Mar - 23 May: Study period VT2</li>
-          <li>19 May - 19 May: Self study</li>
-          <li>22 May - 23 May: Scedule time</li>
-          <li>24 May - 26 May: Self study</li>
-          <li>29 May - 3 Jun: Examination period VT2</li>
-          <li>5 Jun - 5 Jun: Re-examination period VT1</li>
-          <li>7 Jun - 9 Jun: Re-examination period VT1</li>
-        </ul>
+        <p><a href="https://liu.se/organisation/liu/lith/terminstider-for-tekniska-hogskolan">Also available from the source</a></p>
         <h2>TekFak Autumn 2023</h2>
         <ul>
           <li>2023-08-28 (v 35) - 2024-01-13 (v 2)</li>
+          <li>15 Aug - 27 Aug: Re-examination period</li>
+          <li>28 Aug - 18 Oct: Study period HT1</li>
+          <li>19 Oct - 20 Oct: Self study</li>
+          <li>23 Oct - 28 Oct: Examination period HT1</li>
+          <li>30 Oct - 22 Dec: Study Period HT2</li>
+          <li>27 Dec - 29 Dec: Self study</li>
+          <li>2 Jan - 5 Jan: Re-examination period HT1+VT2</li>
+          <li>8 Jan - 13 Jan: Examination period HT2</li>
+        </ul>
+        <h2>TekFak Spring 2024</h2>
+        <ul>
+          <li>15 Jan - 8 Mar: Study period VT1</li>
+          <li>11 Mar - 11 Mar: Self study</li>
+          <li>12 Mar - 15 Mar: Re-examination period HT2</li>
+          <li>18 Mar - 23 Mar: Examination period VT1</li>
+          <li>25 Mar - 22 May: Study Period VT2</li>
+          <li>23 May - 24 May: Self Study</li>
+          <li>27 May - 1 Jun: Examination period VT2</li>
+          <li>3 Jun - 5 Jun: Re-examination period VT1</li>
+          <li>7 Jun - 7 Jun: Re-examination period VT1</li>
         </ul>
       </div>
       <div className="FilFak">


### PR DESCRIPTION
Uppdaterade terminstiderna till HT23-VT24. Noterade även att LiU nu publicerar terminstiderna tillgängligt, så länkade även dit.

HT24 och mer framåt finns också tillgängligt, dock utan omtenta-P under Nolle-P. Det värkar mysko, så jag utelämnade det.