### PR TITLE
Lägg till knapp som länkar till LiUs MazeMap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,5 +70,6 @@
 
 .Github {
   text-align: center;
+  margin-top: 20px;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -17,6 +17,7 @@
   flex-grow: 1;
   flex-direction: column;
   padding: 10px;
+  margin-top: 20px;
   border: 1px solid gray;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -62,6 +62,12 @@
   cursor: pointer;
 }
 
+.Karta {
+  background-color: rgb(247, 126, 215);
+  color: black;
+  cursor: pointer;
+}
+
 .Github {
   text-align: center;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,13 +68,13 @@ function App() {
         </div>
       </div>
 
+      <TerminsTider show={termin} />
+
       <Link to="https://github.com/williamtorberntsson/openliunet" target="_blank" rel="noopener noreferrer">
         <div className='Github'>
           Github page to contribute!
         </div>
       </Link>
-
-      <TerminsTider show={termin} />
 
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,14 @@ function App() {
             <u>Terminstider</u>
           </div>
         </div>
+
+        <div className="Button">
+          <Link to="https://use.mazemap.com/#v=1&config=liu" target="_blank" rel="noopener noreferrer">
+            <div className='Text Karta'>
+              Karta
+            </div>
+          </Link>
+        </div>
       </div>
 
       <Link to="https://github.com/williamtorberntsson/openliunet" target="_blank" rel="noopener noreferrer">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import TerminsTider from './TerminsTider';
+import Karta from './Karta';
 import './App.css';
 
 function App() {
 
   const [termin, setTermin] = useState(false);
+  const [karta, setKarta] = useState(false);
 
   const toggleTermin = () => setTermin(!termin);
+  const toggleKarta = () => setKarta(!karta)
 
   return (
     <div className='Main'>
@@ -59,16 +62,16 @@ function App() {
           </div>
         </div>
 
-        <div className="Button">
-          <Link to="https://use.mazemap.com/#v=1&config=liu" target="_blank" rel="noopener noreferrer">
+        <div className="Button" onClick={toggleKarta}>
             <div className='Text Karta'>
-              Karta
+              <u>Karta</u>
             </div>
-          </Link>
         </div>
       </div>
 
       <TerminsTider show={termin} />
+
+      <Karta show={karta} />
 
       <Link to="https://github.com/williamtorberntsson/openliunet" target="_blank" rel="noopener noreferrer">
         <div className='Github'>

--- a/src/Karta.jsx
+++ b/src/Karta.jsx
@@ -8,7 +8,7 @@ const Karta = ({ show }) => {
   return (
     <div className="Information">
       <div className="Tekfak">
-        <h2>Campus kartor</h2>
+        <h2>Campuskartor</h2>
         <ul>
           <li>
             <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=2&center=15.576785,58.398489&zoom=15.1&campusid=742">Campus Valla</a>

--- a/src/Karta.jsx
+++ b/src/Karta.jsx
@@ -8,16 +8,16 @@ const Karta = ({ show }) => {
   return (
     <div className="Information">
       <div className="Tekfak">
-        <h2>Campus karta</h2>
+        <h2>Campus kartor</h2>
         <ul>
           <li>
-            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=2&center=15.576785,58.398489&zoom=15.1&campusid=742">Campus Linköping</a>
-          </li>
-          <li>
-            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=1&center=16.176629,58.588978&zoom=16.1&campusid=754">Campus Norrköping</a>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=2&center=15.576785,58.398489&zoom=15.1&campusid=742">Campus Valla</a>
           </li>
           <li>
             <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=9&center=15.619532,58.401014&zoom=15.9&campusid=781">Campus US</a>
+          </li>
+          <li>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=1&center=16.176629,58.588978&zoom=16.1&campusid=754">Campus Norrköping</a>
           </li>
           <li>
             <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=1&center=18.143572,59.351345&zoom=17.2&campusid=753">Campus Lidingö</a>

--- a/src/Karta.jsx
+++ b/src/Karta.jsx
@@ -1,0 +1,31 @@
+import "./App.css";
+
+const Karta = ({ show }) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <div className="Information">
+      <div className="Tekfak">
+        <h2>Campus karta</h2>
+        <ul>
+          <li>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=2&center=15.576785,58.398489&zoom=15.1&campusid=742">Campus Linköping</a>
+          </li>
+          <li>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=1&center=16.176629,58.588978&zoom=16.1&campusid=754">Campus Norrköping</a>
+          </li>
+          <li>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=9&center=15.619532,58.401014&zoom=15.9&campusid=781">Campus US</a>
+          </li>
+          <li>
+            <a href="https://use.mazemap.com/#v=1&config=liu&zlevel=1&center=18.143572,59.351345&zoom=17.2&campusid=753">Campus Lidingö</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default Karta;


### PR DESCRIPTION
LiU har fått en ny jättefin karta som jag tycker vi bör länka till här! Öppen för att byta färg eller döpa om knappen till t.ex. "Hitta sal" och lägga den under "Boka sal"-knappen.

![image](https://github.com/williamtorberntsson/openliunet/assets/24913737/51b650c6-9bc8-434a-8e50-c6dd54a4bef3)

Knappen tar dig till en utzoomad vy av den här kartan

![image](https://github.com/williamtorberntsson/openliunet/assets/24913737/b03e3467-69c5-43cf-8fe6-26dc99c2a920)

Lite osäker om den passar in däremot. Jag föreställde mig den här sidan som en samlingsplats för användbara länkar för LiU studenter, så i den bemärkelsen gillar jag kartan. Kartan är däremot öppet tillgänglig för alla, men det är t.ex. terminstider och tentastatistik också. För minit behöver man alltid logga in, men även den finns med på sidan. 